### PR TITLE
Use absolute path when including settings.php (fixes a PHP fatal error)

### DIFF
--- a/init.php
+++ b/init.php
@@ -22,4 +22,4 @@ function vcfj_load_plugin_textdomain() {
 add_action( 'plugins_loaded', 'vcfj_load_plugin_textdomain' );
 
 // Include the settings page
-include_once( 'settings.php');
+include_once( plugin_dir_path( __FILE__ ) . 'settings.php');


### PR DESCRIPTION
The file `settings.php` was included with a relative path and in a multi-site install, when visiting `update-core.php` this causes a PHP fatal error.

![jquery-version-control--include_path--fatal-error](https://cloud.githubusercontent.com/assets/1355810/20053609/0962a2be-a4e2-11e6-9bf0-8752e82c3390.png)
